### PR TITLE
Linux compilation

### DIFF
--- a/3drepocli.pro
+++ b/3drepocli.pro
@@ -33,7 +33,7 @@ QT += core gui # TODO: remove Qt dependencies, ie it should be -=
 
 win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/release/ -l3drepocore
 else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/debug/ -l3drepocore
-else:unix: LIBS += -L$$OUT_PWD/ -l3drepocore
+else:unix: LIBS += -L$$OUT_PWD/ -lboost_system -l3drepocore
 
 INCLUDEPATH += $$PWD/src
 DEPENDPATH += $$PWD/src

--- a/3drepocore.pro
+++ b/3drepocore.pro
@@ -36,6 +36,7 @@ win32:DEFINES += _WIN32
 unix {
     target.path = /usr/lib
     INSTALLS += target
+    LIBS += -lboost_system -lboost_thread -lboost_filesystem
 }
 
 HEADERS +=  src/repocore.h\

--- a/src/assimpwrapper.cpp
+++ b/src/assimpwrapper.cpp
@@ -66,8 +66,8 @@ bool repo::core::AssimpWrapper::importModel(const std::string &fileName,
 	// post processor
 	// http://assimp.sourceforge.net/lib_html/ai_post_process_8h.html#64795260b95f5a4b3f3dc1be4f52e410
 	
-    AI_SLM_DEFAULT_MAX_VERTICES; // 1,000,000 by default
-    AI_SLM_DEFAULT_MAX_TRIANGLES; // 1,000,000 by default
+    // AI_SLM_DEFAULT_MAX_VERTICES; // 1,000,000 by default
+    // AI_SLM_DEFAULT_MAX_TRIANGLES; // 1,000,000 by default
 
 	//-------------------------------------------------------------------------
     // In OpenGL ES 2.0 and WebGL, vertices are 16-bit
@@ -157,6 +157,11 @@ bool repo::core::AssimpWrapper::exportModel(
             break;
         case aiReturn_OUTOFMEMORY :
             std::cerr << "Export failed due to running out of memory." << std::endl;
+            break;
+        case aiReturn_SUCCESS :
+            break;
+        case _AI_ENFORCE_ENUM_SIZE :
+            // Silently handle assimp's bogus enum-size-enforcing value.
             break;
     }
     return (ret == aiReturn_SUCCESS);

--- a/src/graph/repo_node_abstract.h
+++ b/src/graph/repo_node_abstract.h
@@ -268,11 +268,11 @@ protected :
 	
 	std::string type; //!< Compulsory type of this document.
 
-	boost::uuids::uuid uniqueID; //!< Compulsory unique database document identifier.
+	unsigned int api; //!< Compulsory API level of this document (used to decode).
 
 	boost::uuids::uuid sharedID; //!< Shared unique graph document identifier.
 
-	unsigned int api; //!< Compulsory API level of this document (used to decode).
+	boost::uuids::uuid uniqueID; //!< Compulsory unique database document identifier.
 
 	std::string name; //!< Optional name of this document.
 

--- a/src/graph/repo_node_mesh.cpp
+++ b/src/graph/repo_node_mesh.cpp
@@ -585,7 +585,7 @@ double repo::core::RepoNodeMesh::getFacesBoundaryLength(
 {
 	double boundaryLength = 0;
 	const aiFace & faceA = faces->at(faceIndexA);
-	const aiFace & faceB = faces->at(faceIndexA);
+	const aiFace & faceB = faces->at(faceIndexB);
 		
 	std::vector<repo::core::RepoVertex> commonVertices;
 	for (unsigned int i = 0; i < faceA.mNumIndices; ++i)

--- a/src/graph/repo_node_mesh.h
+++ b/src/graph/repo_node_mesh.h
@@ -227,6 +227,8 @@ public :
 
 protected :
 
+    std::vector<aiVector3t<float> > *vertices; //!< Vertices of this mesh.
+
 	//! Faces of the mesh. Each face points to several vertices by the indices.
 	std::vector<aiFace> * faces; 
 
@@ -235,8 +237,6 @@ protected :
 	 * Assimp assigns QNaN to normals for points and lines.
 	 */
     std::vector<aiVector3t<float> > *normals;
-
-    std::vector<aiVector3t<float> > *vertices; //!< Vertices of this mesh.
 
 	//! 2D outline of this mesh.
 	/*!

--- a/src/graph/repo_node_metadata.cpp
+++ b/src/graph/repo_node_metadata.cpp
@@ -24,7 +24,7 @@ repo::core::RepoNodeMetadata::RepoNodeMetadata(const aiMetadata *metaIn) :
 {
 	mongo::BSONObjBuilder builder;
 
-	for(int i = 0; i < metaIn->mNumProperties; i++)
+	for(unsigned int i = 0; i < metaIn->mNumProperties; i++)
 	{
 		std::string key(metaIn->mKeys[i].C_Str());
 		aiMetadataEntry &currentValue = metaIn->mValues[i];
@@ -64,6 +64,10 @@ repo::core::RepoNodeMetadata::RepoNodeMetadata(const aiMetadata *metaIn) :
 						*(static_cast<aiVector3D *>(currentValue.mData)),
 						builder);
 				break;
+            case FORCE_32BIT:
+                // Gracefully (but silently) handle the bogus enum used by
+                // assimp to ensure the enum is 32-bits.
+                break;
 		}
 	}
 

--- a/src/mongoclientwrapper.cpp
+++ b/src/mongoclientwrapper.cpp
@@ -11,10 +11,10 @@
 #include <cstring>
 #include <cstdint>
 
-// http://msdn.microsoft.com/en-us/library/ttcz0bys.aspx
-#pragma warning(disable : 4996) 
-
 #if defined(_WIN32) || defined(_WIN64)
+  // http://msdn.microsoft.com/en-us/library/ttcz0bys.aspx
+  #pragma warning(disable : 4996)
+
   #define strcasecmp _stricmp
 #endif
 
@@ -151,7 +151,7 @@ std::string repo::core::MongoClientWrapper::uuidToString(
 int repo::core::MongoClientWrapper::retrieveRevisionNumber(
     const mongo::BSONObj &obj)
 {
-	int revision;
+	int revision = 0;
 	if (obj.hasField("revision"))
 	{
 		if (obj.getField("revision").type() == mongo::NumberInt)
@@ -633,7 +633,7 @@ bool repo::core::MongoClientWrapper::fetchEntireCollection(
 	std::vector<mongo::BSONObj> &ret)
 {		
 	// TODO: fix this to make sure infinite loops cannot occur if someone deletes something from db in the meantime.
-	int retrieved = 0;
+	unsigned long long retrieved = 0;
 	unsigned long long count = countItemsInCollection(database, collection);	
 	while (count > retrieved)
 	{
@@ -658,6 +658,10 @@ void repo::core::MongoClientWrapper::getRevision(
 {	
 	// this works fine, however, the entire query is returned as single BSON object
 	// which is limited to 16MB
+
+    // TODO: Use these parameters :)
+    (void)revNumber;
+    (void)ancestor;
 
 	// TODO fix ancestral array [0,1]!!!
 	std::stringstream sstr;
@@ -828,7 +832,7 @@ void repo::core::MongoClientWrapper::insertRecords(
 	bool inReverse)
 {
 	if (inReverse)
-		for (unsigned int i = objs.size() - 1; i >= 0; --i)
+		for (int i = objs.size() - 1; i >= 0; --i)
 			insertRecord(database, collection, objs[i]);	
 	else 
 		for (unsigned int i = 0; i < objs.size(); ++i)

--- a/src/primitives/repo_vertex.cpp
+++ b/src/primitives/repo_vertex.cpp
@@ -277,11 +277,14 @@ T repo::core::RepoVertex::distancePointToTriangleSquared(
     }
 
     //mClosestPoint0 = pointP;
-    aiVector3t<T> mClosestPoint1 = trianglePointA + s*edge0 + t*edge1;
-	aiVector3t<T> mTriangleBary;
-    mTriangleBary.y = s;
-    mTriangleBary.z = t;
-    mTriangleBary.x = (T)1 - s - t;
+    // This code from the original source isn't needed in this case because
+    // we're just returning sqr(distance) rather than the parameters of the
+    // triangle that's been chosen.
+//    aiVector3t<T> mClosestPoint1 = trianglePointA + s*edge0 + t*edge1;
+//    aiVector3t<T> mTriangleBary;
+//    mTriangleBary.y = s;
+//    mTriangleBary.z = t;
+//    mTriangleBary.x = (T)1 - s - t;
     return sqrDistance;
 }
 

--- a/src/primitives/repostreambuffer.cpp
+++ b/src/primitives/repostreambuffer.cpp
@@ -21,8 +21,8 @@ repo::core::RepoStreamBuffer::RepoStreamBuffer(
         RepoAbstractListener *interceptor,
         std::ostream &stream)
     : listener(interceptor)
-    , originalStream(stream)
     , originalBuffer(0)
+    , originalStream(stream)
     , redirectStream(0)
 {
     originalBuffer = originalStream.rdbuf(this);


### PR DESCRIPTION
Added libraries to linker to get it compiling on Linux x86-64 with g++ 4.8.2.
Fixed (occasionally pedantic) warnings except for deprecated std::auto_ptr warnings.
If we're using C++11, we should move from std::auto_ptr<> to C++11's native variety.
